### PR TITLE
Add config option to adjust the size of the holo display

### DIFF
--- a/src/main/java/net/dries007/holoInventory/Config.java
+++ b/src/main/java/net/dries007/holoInventory/Config.java
@@ -56,6 +56,7 @@ public class Config
     public boolean keyState = false;
     public boolean rotateItems = true;
     public boolean debug = false;
+    public double renderScaling = 1.0;
 
     public ArrayList<String> bannedTiles = new ArrayList<String>();
     public ArrayList<String> bannedEntities = new ArrayList<String>();
@@ -97,6 +98,8 @@ public class Config
     public void doConfig()
     {
         configuration.addCustomCategoryComment(MODID, "All our settings are in here, as you might expect...");
+
+        renderScaling = configuration.get(MODID, "renderScaling", renderScaling, "Visual scale factor (0.0-1.0)").getDouble(1.0);
 
         colorEnable = configuration.get(MODID, "colorEnable", colorEnable, "Enable a BG color").getBoolean(false);
         colorAlpha = configuration.get(MODID, "colorAlpha", colorAlpha, "The BG transparancy (0-255)").getInt();

--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -167,6 +167,10 @@ public class Renderer
         glPushMatrix();
         moveAndRotate(-0.25);
 
+        double uiScaleFactor = HoloInventory.getConfig().renderScaling;
+        if (uiScaleFactor < 0.1) uiScaleFactor = 0.1;
+        glScaled(uiScaleFactor, uiScaleFactor, uiScaleFactor);
+
         // Values for later
         timeD = (float) (360.0 * (double) (System.currentTimeMillis() & 0x3FFFL) / (double) 0x3FFFL);
         maxColumns = 3;
@@ -291,7 +295,12 @@ public class Renderer
     {
         // Move to right position and rotate to face the player
         glPushMatrix();
+
         moveAndRotate(-1);
+        
+        double uiScaleFactor = HoloInventory.getConfig().renderScaling;
+        if (uiScaleFactor < 0.1) uiScaleFactor = 0.1;
+        glScaled(uiScaleFactor, uiScaleFactor, uiScaleFactor);
 
         // Values for later
         timeD = (float) (360.0 * (double) (System.currentTimeMillis() & 0x3FFFL) / (double) 0x3FFFL);


### PR DESCRIPTION
Config is called renderScaling. The description says 0.0-1.0, but really the minimum value is 0.1 (because 0 and you can barely see it at even 0.2). The maximum value is also unbounded by the code.

I initially tried to adjust the blockScaleModifier, but that didn't take (the factor is used in lots of places so maybe I missed something), so I pushed the scale matrix earlier in the stack instead. Maybe heavy-handed but it does the job, and it adjusts text scaling too.