### PR TITLE
Clients are no longer forced to install when HoloInventory installed server-side

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "2.0.2"
+version = "2.0.3"
 if (System.getenv().BUILD_NUMBER != null) version += "." + System.getenv().BUILD_NUMBER
 
 targetCompatibility = 1.7

--- a/src/main/java/net/dries007/holoInventory/HoloInventory.java
+++ b/src/main/java/net/dries007/holoInventory/HoloInventory.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Logger;
 
 import static net.dries007.holoInventory.HoloInventory.*;
 
-@Mod(modid = MODID, name = MODID, canBeDeactivated = true, updateJSON = URL + "update.json", guiFactory = GUI_FACTORY)
+@Mod(modid = MODID, name = MODID, acceptableRemoteVersions = "*", canBeDeactivated = true, updateJSON = URL + "update.json", guiFactory = GUI_FACTORY)
 public class HoloInventory
 {
     public static final String MODID = "HoloInventory";


### PR DESCRIPTION
It is now optional for clients to install HoloInventory when it is installed server-side. Clients who don't install it will be able to connect normally, not being kicked for not having the mod, those who do will be able to experience the mod as usual. 