### PR TITLE
Added API for mods using IItemHandlers

### DIFF
--- a/src/main/java/net/dries007/holoInventory/api/INamedItemHandler.java
+++ b/src/main/java/net/dries007/holoInventory/api/INamedItemHandler.java
@@ -1,0 +1,9 @@
+package net.dries007.holoInventory.api;
+
+public interface INamedItemHandler {
+
+	/*
+	 * Option for other mods using IItemHandler to have their names properly detected
+	 */
+	String getItemHandlerName();
+}

--- a/src/main/java/net/dries007/holoInventory/network/request/TileRequest.java
+++ b/src/main/java/net/dries007/holoInventory/network/request/TileRequest.java
@@ -26,6 +26,7 @@ package net.dries007.holoInventory.network.request;
 import io.netty.buffer.ByteBuf;
 import net.dries007.holoInventory.Helper;
 import net.dries007.holoInventory.HoloInventory;
+import net.dries007.holoInventory.api.INamedItemHandler;
 import net.dries007.holoInventory.network.response.PlainInventory;
 import net.dries007.holoInventory.network.response.ResponseMessage;
 import net.minecraft.block.Block;
@@ -123,6 +124,10 @@ public class TileRequest extends RequestMessage
                 {
                     HoloInventory.getLogger().warn("Error: Block at {} (Class: {} Te: {} Block: {}) returned null after indicating the capability is available.", message.pos, te.getClass().getName(), te, te.getBlockType());
                     return null;
+                }
+                if (te instanceof INamedItemHandler) {
+                	INamedItemHandler namedHandler = (INamedItemHandler) te;
+                	return new PlainInventory(message.pos, namedHandler.getItemHandlerName(), iih);
                 }
                 return new PlainInventory(message.pos, te.getBlockType().getUnlocalizedName(), iih);
             }


### PR DESCRIPTION
Just getting the block's unlocalized name isn't enough for blocks that are metadata sensitive. This provides other mods w/ such blocks a way to get their containers properly localized.